### PR TITLE
chore: package.json dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react": "^16.7.0",
     "react-native": "^0.57.8"
   },
-  "dependencies": {
+  "peerDependencies": {
     "lodash": "~4.17.21",
     "react-native-table-component": "~1.2.1",
     "lottie-react-native": "~5.0.1"


### PR DESCRIPTION
hi @chownchen 请通过一下这个pull-request，然后重新更新一个版本到npm上，谢谢！

我把 package.json 里的 dependencies 换成 peerDependencies了，原因有两点：

1. 这样项目使用的时候就可以选择自己的版本了，不需要固定依赖库的版本
2. lottie-react-native 这个库是原生库，如果项目本身已经有一个版本了，这里又指定另一个版本的话，会有冲突的。

谢谢！